### PR TITLE
Fix Series class "previous" property name typo

### DIFF
--- a/marvel/series.py
+++ b/marvel/series.py
@@ -100,7 +100,7 @@ class Series(MarvelObject):
         return SeriesSummary(self.marvel, self.dict['next'])
 
     @property
-    def previoius(self):
+    def previous(self):
         return SeriesSummary(self.marvel, self.dict['previous'])
         
     def get_creators(self, *args, **kwargs):


### PR DESCRIPTION
Spotted a minor typo in one of the properties of the Series class.

Thanks for creating this awesome wrapper by the way :)
